### PR TITLE
Scan files, return result objects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
         image: lokori/clamav-java
         ports:
           - 3310:3310
+        volumes:
+          - /tmp:/tmp
 
     steps:
     - name: Checkout repository
@@ -30,4 +32,4 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build and test with Maven
-      run: mvn -B -U clean install
+      run: mvn -B -U clean install -Djava.io.tmpdir=/tmp

--- a/src/main/java/fi/solita/clamav/ClamAVClient.java
+++ b/src/main/java/fi/solita/clamav/ClamAVClient.java
@@ -66,6 +66,20 @@ public class ClamAVClient {
   }
 
   /**
+   * Streams the given data to the server in chunks and returns a ScanResult indicating the outcome.
+   *
+   * @param is data to scan. Not closed by this method!
+   * @return server reply as ScanResult
+   */
+  public ScanResult scanWithResult(InputStream is) {
+      try {
+          return new ScanResult(scan(is));
+      } catch (Exception e) {
+          return new ScanResult(e);
+      }
+  }
+
+  /**
    * Streams the given data to the server in chunks. The whole data is not kept in memory.
    * This method is preferred if you don't want to keep the data in memory, for instance by scanning a file on disk.
    * Since the parameter InputStream is not reset, you can not use the stream afterwards, as it will be left in a EOF-state.
@@ -110,6 +124,20 @@ public class ClamAVClient {
         return assertSizeLimit(readAll(clamIs));
       }
     }
+  }
+
+  /**
+   * Scans bytes for virus by passing the bytes to clamav
+   *
+   * @param in data to scan
+   * @return server reply as a ScanResult
+   **/
+  public ScanResult scanWithResult(byte[] in) {
+      try {
+          return new ScanResult(scan(in));
+      } catch (Exception e) {
+          return new ScanResult(e);
+      }
   }
 
   /**

--- a/src/main/java/fi/solita/clamav/ClamAVClient.java
+++ b/src/main/java/fi/solita/clamav/ClamAVClient.java
@@ -182,18 +182,18 @@ public class ClamAVClient {
    * @throws IOException
    */
   public byte[] scan(Path path) throws IOException {
-      try (Socket s = new Socket(hostName, port);
-           OutputStream outs = new BufferedOutputStream(s.getOutputStream())) {
-          s.setSoTimeout(timeout);
+	  try (Socket s = new Socket(hostName, port);
+	  OutputStream outs = new BufferedOutputStream(s.getOutputStream())) {
+		  s.setSoTimeout(timeout);
 
-          // handshake
-          outs.write(asBytes("SCAN " + path.toAbsolutePath() + "\n"));
-          outs.flush();
+		  // handshake
+		  outs.write(asBytes("SCAN " + path.toAbsolutePath() + "\n"));
+		  outs.flush();
 
-          try (InputStream clamIs = s.getInputStream()) {
-              return assertSizeLimit(readAll(clamIs));
-          }
-      }
+		  try (InputStream clamIs = s.getInputStream()) {
+			  return assertSizeLimit(readAll(clamIs));
+		  }
+	  }
   }
 
   /**

--- a/src/main/java/fi/solita/clamav/ScanResult.java
+++ b/src/main/java/fi/solita/clamav/ScanResult.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fi.solita.clamav;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Scan result wrapper.
+ *
+ * @author bbpennel
+ * @author philvarner
+ */
+public class ScanResult {
+
+    private String result = "";
+    private Status status = Status.FAILED;
+    private String signature = "";
+    private Exception exception = null;
+
+    public enum Status { PASSED, FAILED, ERROR }
+
+    public static final String STREAM_PREFIX = "stream: ";
+    public static final String RESPONSE_OK = "stream: OK";
+    public static final String FOUND_SUFFIX = "FOUND";
+    public static final String ERROR_SUFFIX = "ERROR";
+
+    public ScanResult(byte[] result) {
+        this.result = new String(result, StandardCharsets.US_ASCII);
+    }
+
+    public ScanResult(Exception ex) {
+        setException(ex);
+        setStatus(Status.ERROR);
+    }
+
+    /**
+     * @return Exception thrown by the scan
+     */
+    public Exception getException() {
+        return exception;
+    }
+
+    public void setException(Exception exception) {
+        this.exception = exception;
+    }
+
+    /**
+     * @return the raw response output from the scan, as a string
+     */
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+
+        if (result == null) {
+            setStatus(Status.ERROR);
+        } else if (RESPONSE_OK.equals(result)) {
+            setStatus(Status.PASSED);
+        } else if (result.endsWith(FOUND_SUFFIX)) {
+            setSignature(result.substring(STREAM_PREFIX.length(), result.lastIndexOf(FOUND_SUFFIX) - 1));
+        } else if (result.endsWith(ERROR_SUFFIX)) {
+            setStatus(Status.ERROR);
+        }
+    }
+
+    /**
+     * @return Signature of the FOUND issue, or an empty string.
+     */
+    public String getSignature() {
+        return signature;
+    }
+
+    public void setSignature(String signature) {
+        this.signature = signature;
+    }
+
+    /**
+     * @return Status of the scan
+     */
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/src/test/java/fi/solita/clamav/InstreamTest.java
+++ b/src/test/java/fi/solita/clamav/InstreamTest.java
@@ -17,6 +17,9 @@ public class InstreamTest {
 
   private static String CLAMAV_HOST = "localhost";
 
+  private static final String EICAR =
+          "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
+
   private byte[] scan(byte[] input) throws UnknownHostException, IOException  {
     ClamAVClient cl = new ClamAVClient(CLAMAV_HOST, 3310);
     return cl.scan(input);
@@ -35,8 +38,8 @@ public class InstreamTest {
   @Test
   public void testPositive() throws UnknownHostException, IOException {
     // http://www.eicar.org/86-0-Intended-use.html
-    byte[] EICAR = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*".getBytes("ASCII");
-    byte[] r =  scan(EICAR);
+    byte[] bytes = EICAR.getBytes("ASCII");
+    byte[] r =  scan(bytes);
     assertFalse(ClamAVClient.isCleanReply(r));
   }
 
@@ -72,5 +75,15 @@ public class InstreamTest {
       cl.setMaxStreamSize(10000);
       ScanResult result = cl.scanWithResult(new SlowInputStream());
       assertEquals(ScanResult.Status.PASSED, result.getStatus());
+  }
+
+  //Only the first 10000 bytes will be scanned, so it will not reach size limit
+  @Test
+  public void testMaxStreamSizePositive() throws UnknownHostException, IOException {
+     ClamAVClient cl = new ClamAVClient(CLAMAV_HOST, 3310);
+     cl.setMaxStreamSize(10000);
+     byte[] bytes = EICAR.getBytes("ASCII");
+     ScanResult result = cl.scanWithResult(bytes);
+     assertEquals(ScanResult.Status.FOUND, result.getStatus());
   }
 }

--- a/src/test/java/fi/solita/clamav/ScanTest.java
+++ b/src/test/java/fi/solita/clamav/ScanTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fi.solita.clamav;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author bbpennel
+ */
+public class ScanTest {
+    private static String CLAMAV_HOST = "localhost";
+    private static final String EICAR =
+            "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private ClamAVClient client;
+
+    @Before
+    public void setup() throws Exception {
+        tmpFolder.create();
+        client = new ClamAVClient(CLAMAV_HOST, 3310);
+    }
+
+    @Test
+    public void testPositive() throws Exception {
+        File scanFile = tmpFolder.newFile();
+        Files.write(scanFile.toPath(), EICAR.getBytes("ASCII"));
+        ScanResult result = client.scanWithResult(scanFile.toPath());
+        assertEquals(ScanResult.Status.FOUND, result.getStatus());
+        assertEquals("Win.Test.EICAR_HDB-1", result.getSignature());
+    }
+
+    @Test
+    public void testPassed() throws Exception {
+        File scanFile = tmpFolder.newFile();
+        Files.write(scanFile.toPath(), "Random text here".getBytes());
+        ScanResult result = client.scanWithResult(scanFile.toPath());
+        assertEquals(ScanResult.Status.PASSED, result.getStatus());
+        assertNull(result.getSignature());
+    }
+
+    @Test
+    public void testFileNotFound() throws Exception {
+        File scanFile = new File(tmpFolder.getRoot(), "notExist.txt");
+        ScanResult result = client.scanWithResult(scanFile.toPath());
+        assertEquals(ScanResult.Status.ERROR, result.getStatus());
+        assertNull(result.getSignature());
+    }
+}


### PR DESCRIPTION
* Optional signatures to get scan results in a wrapper class
* Adds methods for scanning files using SCAN instead of INSTREAM
* Adds optional parameter for scanner to cap the number of bytes that will be sent via INSTREAM rather than failing, so that only the first N bytes will be scanned (similar to MaxFileSize for the SCAN command)